### PR TITLE
Add configurable authentication guard and user field mapping

### DIFF
--- a/src/Controllers/TicketController.php
+++ b/src/Controllers/TicketController.php
@@ -20,16 +20,37 @@ class TicketController extends Controller
         );
     }
 
+    /**
+     * Obtiene el usuario autenticado usando el guard configurado.
+     */
+    protected function authUser()
+    {
+        $guard = config('3312client.auth_guard');
+
+        return Auth::guard($guard)->user();
+    }
+
+    /**
+     * Obtiene un campo del usuario autenticado usando el mapeo de campos configurado.
+     */
+    protected function userField(string $field): ?string
+    {
+        $user = $this->authUser();
+        $mappedField = config("3312client.user_fields.{$field}", $field);
+
+        return $user?->{$mappedField};
+    }
+
     public function index()
     {
-        $tickets = $this->ticketService->obtenerTickets(Auth::user()->email)->json();
+        $tickets = $this->ticketService->obtenerTickets($this->userField('email'))->json();
         $tiposTicket = $this->ticketService->obtenerTiposTicket()->json();
         return view($this->getView('index'), compact('tickets', 'tiposTicket'));
     }
 
     public function show($ticketId)
     {
-        $ticket = $this->ticketService->obtenerTicket(Auth::user()->email, $ticketId)->json();
+        $ticket = $this->ticketService->obtenerTicket($this->userField('email'), $ticketId)->json();
         return view($this->getView('show'), compact('ticket'));
     }
 
@@ -72,7 +93,7 @@ class TicketController extends Controller
         ]);
 
         $archivos = $request->file('archivos', []);
-        $response = $this->ticketService->responderTicket(Auth::user()->email, $ticketId, $request->respuesta, $archivos);
+        $response = $this->ticketService->responderTicket($this->userField('email'), $ticketId, $request->respuesta, $archivos);
 
         if ($response->successful()) {
             flash('Respuesta enviada exitosamente')->success();
@@ -84,7 +105,7 @@ class TicketController extends Controller
 
     public function cerrar($ticketId)
     {
-        $response = $this->ticketService->cerrarTicket(Auth::user()->email, $ticketId);
+        $response = $this->ticketService->cerrarTicket($this->userField('email'), $ticketId);
 
         if ($response->successful()) {
             flash('Ticket cerrado exitosamente')->success();

--- a/src/config/3312client.php
+++ b/src/config/3312client.php
@@ -9,4 +9,30 @@ return [
     // Ruta de retorno al sistema principal (puede ser nombre de ruta o URL)
     // Ejemplo: 'dashboard' o 'admin.dashboard' o '/dashboard'
     'back_route' => env('SOPORTE_BACK_ROUTE', null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Autenticación
+    |--------------------------------------------------------------------------
+    |
+    | Configuración del guard y modelo autenticable que utiliza el package.
+    |
+    | 'auth_guard' => null usa el guard por defecto de Laravel (normalmente 'web').
+    | Puede cambiarse a 'admin', 'api', o cualquier guard definido en config/auth.php.
+    |
+    | 'auth_middleware' => El middleware de autenticación a aplicar en las rutas.
+    | Ejemplos: 'auth', 'auth:admin', 'auth:api'
+    |
+    | 'user_fields' => Mapeo de los campos del modelo autenticable.
+    | Permite adaptar el package a cualquier modelo (User, Admin, Cliente, etc.)
+    | sin importar cómo se llamen sus columnas.
+    |
+    */
+    'auth_guard' => env('SOPORTE_AUTH_GUARD', null),
+    'auth_middleware' => env('SOPORTE_AUTH_MIDDLEWARE', 'auth'),
+    'user_fields' => [
+        'name' => 'name',
+        'lastname' => 'lastname',
+        'email' => 'email',
+    ],
 ];

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -3,7 +3,9 @@
 use Illuminate\Support\Facades\Route;
 use Chondal\TicketSoporte\Controllers\TicketController;
 
-Route::middleware(['web', 'auth'])->prefix('soporte')->name('soporte.')->group(function () {
+$authMiddleware = config('3312client.auth_middleware', 'auth');
+
+Route::middleware(['web', $authMiddleware])->prefix('soporte')->name('soporte.')->group(function () {
     Route::get('/tickets/listado', [TicketController::class, 'index'])->name('index');
     Route::get('/ticket/{ticket}', [TicketController::class, 'show'])->name('show');
     Route::post('/crear', [TicketController::class, 'store'])->name('store');

--- a/src/views/bootstrap5/formulario-soporte.blade.php
+++ b/src/views/bootstrap5/formulario-soporte.blade.php
@@ -13,8 +13,13 @@
                 @csrf
                 <div class="modal-body">
 
-                    <input type="hidden" name="name" value="{{ Auth::check() ? Auth::user()->name : '' }}" required>
-                    <input type="hidden" name="lastname" value="{{ Auth::check() ? Auth::user()->lastname : '' }}" required>
+                    @php
+                        $__soporteGuard = config('3312client.auth_guard');
+                        $__soporteUser = Auth::guard($__soporteGuard)->user();
+                        $__soporteFields = config('3312client.user_fields', []);
+                    @endphp
+                    <input type="hidden" name="name" value="{{ $__soporteUser?->{$__soporteFields['name'] ?? 'name'} ?? '' }}" required>
+                    <input type="hidden" name="lastname" value="{{ $__soporteUser?->{$__soporteFields['lastname'] ?? 'lastname'} ?? '' }}" required>
                     <input type="hidden" name="current_url" value="{{ url()->current() }}">
 
                     <div class="row">
@@ -22,8 +27,8 @@
                             <div class="mb-3">
                                 <label for="email" class="form-label">✉️ Email</label>
                                 <input readonly type="email" class="form-control form-control-sm" id="email" name="email"
-                                    value="{{ Auth::check() ? Auth::user()->email : '' }}"
-                                    {{ Auth::check() ? 'readonly' : '' }} required>
+                                    value="{{ $__soporteUser?->{$__soporteFields['email'] ?? 'email'} ?? '' }}"
+                                    {{ $__soporteUser ? 'readonly' : '' }} required>
                             </div>
                         </div>
 

--- a/src/views/bootstrap5/layouts/3312client.blade.php
+++ b/src/views/bootstrap5/layouts/3312client.blade.php
@@ -397,16 +397,22 @@
                 </div>
             </div>
 
+            @php
+                $__soporteGuard = config('3312client.auth_guard');
+                $__soporteUser = Auth::guard($__soporteGuard)->user();
+                $__soporteFields = config('3312client.user_fields', []);
+                $__soporteUserName = $__soporteUser?->{$__soporteFields['name'] ?? 'name'} ?? 'Usuario';
+            @endphp
             <div class="d-flex align-items-center gap-3">
-                @auth
+                @if($__soporteUser)
                 <div class="dropdown">
                     <a href="#" class="d-flex align-items-center text-decoration-none dropdown-toggle hide-arrow" data-bs-toggle="dropdown">
-                        <img src="https://ui-avatars.com/api/?name={{ urlencode(auth()->user()->name ?? 'Usuario') }}&background=435ebe&color=fff" 
-                             class="avatar shadow-sm" 
-                             alt="{{ auth()->user()->name ?? 'Usuario' }}">
+                        <img src="https://ui-avatars.com/api/?name={{ urlencode($__soporteUserName) }}&background=435ebe&color=fff"
+                             class="avatar shadow-sm"
+                             alt="{{ $__soporteUserName }}">
                     </a>
                     <ul class="dropdown-menu dropdown-menu-end border-0 shadow-lg">
-                        <li><h6 class="dropdown-header">Hola, {{ auth()->user()->name ?? 'Usuario' }}</h6></li>
+                        <li><h6 class="dropdown-header">Hola, {{ $__soporteUserName }}</h6></li>
                         <li><hr class="dropdown-divider"></li>
                         <li>
                             <form method="POST" action="{{ route('logout') }}">
@@ -418,7 +424,7 @@
                         </li>
                     </ul>
                 </div>
-                @endauth
+                @endif
             </div>
         </header>
 


### PR DESCRIPTION
## Summary
This PR introduces configurable authentication support to the ticket support package, allowing it to work with different Laravel authentication guards and custom user models with flexible field mapping.

## Key Changes
- **Added helper methods in TicketController**: 
  - `authUser()` - Retrieves the authenticated user using a configurable guard
  - `userField()` - Retrieves specific user fields with support for field name mapping
  
- **Updated all controller methods** to use the new `userField('email')` method instead of directly accessing `Auth::user()->email`, enabling support for custom user models and field names

- **Extended configuration file** (`3312client.php`) with new authentication options:
  - `auth_guard` - Configurable authentication guard (defaults to Laravel's default guard)
  - `auth_middleware` - Configurable authentication middleware for routes
  - `user_fields` - Field mapping configuration for user model attributes (name, lastname, email)

- **Updated route middleware** to use the configurable `auth_middleware` from config instead of hardcoded 'auth'

- **Updated Blade templates** to respect the configured guard and field mappings:
  - `3312client.blade.php` - User dropdown in header now uses configured guard and field mapping
  - `formulario-soporte.blade.php` - Support form now uses configured guard and field mapping

## Implementation Details
- All authentication calls now go through the configured guard, supporting multi-guard setups (e.g., 'web', 'admin', 'api')
- User field mapping allows the package to work with any user model regardless of column naming conventions
- Blade templates use null-safe operators (`?->`) for safe property access
- Configuration is environment-aware through `.env` variables with sensible defaults

https://claude.ai/code/session_01EajWH29siLfDDzu5ju54UV